### PR TITLE
Feat/use stable

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -14,9 +14,6 @@ jobs:
       issues: write  # Required for creating issues
     
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        
       - name: Run documentation checker
         uses: canonical/discourse-doc-checker@main  # Use the actual repository name
         with:

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: 'Working directory'
     required: false
     default: '.'
+  use-stable:
+    description: 'Use stable charm to compare docs for'
+    required: false
+    default: 'true'
   github-token:
     description: 'GitHub token for creating issues'
     required: false
@@ -51,6 +55,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # Required for tag/commit detection
+        
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -61,6 +70,29 @@ runs:
       run: |
         python -m pip install --upgrade pip
         pip install -r ${{ github.action_path }}/requirements.txt
+
+    - name: Detect and checkout stable commit
+      if: inputs.use-stable == 'true'
+      id: stable-commit
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        echo "Detecting stable commit using check_docs script..."
+        
+        # Run the check_docs script to get the stable commit SHA
+        stable_commit=$(python ${{ github.action_path }}/check_docs.py --get-stable-commit 2>/dev/null || echo "")
+        
+        if [[ -n "$stable_commit" && "$stable_commit" != "$(git rev-parse HEAD)" ]]; then
+          echo "Found stable commit: $stable_commit"
+          echo "Checking out stable commit..."
+          git fetch origin "$stable_commit" 2>/dev/null || git fetch --all
+          git checkout "$stable_commit"
+          echo "Successfully checked out stable commit: $(git rev-parse HEAD)"
+          echo "stable_commit=$stable_commit" >> "$GITHUB_OUTPUT"
+        else
+          echo "No stable commit found or already on stable commit, using current state"
+          echo "stable_commit=" >> "$GITHUB_OUTPUT"
+        fi
 
     - name: Check if docs directory exists
       id: docs-check
@@ -74,7 +106,7 @@ runs:
           echo "Warning: Documentation directory '${{ inputs.docs-path }}' not found"
         fi
 
-    - name: Run documentation format check
+    - name: Run documentation comparison
       id: doc-check
       if: steps.docs-check.outputs.exists == 'true'
       shell: bash
@@ -86,7 +118,7 @@ runs:
         DOCS_PATH_GLOB: ${{ inputs.docs-path }}
         CHARM_DIR: ${{ inputs.working-directory }}
       run: |
-        echo "Running documentation format check..."
+        echo "Running documentation comparison..."
         
         # Capture output to both stdout and a file
         output_file="${{ runner.temp }}/doc_check_output.txt"
@@ -168,6 +200,7 @@ runs:
         **Repository:** ${{ github.repository }}
         **Branch:** ${{ github.ref_name }}
         **Commit:** ${{ github.sha }}
+        **Stable Commit:** ${{ steps.stable-commit.outputs.stable_commit || 'Not used' }}
         **Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         **Issue Type:** $issue_type
         **Status:** ${{ steps.doc-check.outputs.check_result || 'skipped' }}

--- a/check_docs.py
+++ b/check_docs.py
@@ -469,13 +469,11 @@ def get_stable_commit() -> Optional[str]:
             print("Could not determine repository name for promote action lookup", file=sys.stderr)
             return None
         
-        print(f"Looking for latest promote action in {owner}/{repo_name}...", file=sys.stderr)
         
         # Use the find_latest_promote_action function to get the stable commit
         stable_commit = find_latest_promote_action(repo=repo_name, owner=owner)
         
         if stable_commit:
-            print(f"Found stable commit from promote action: {stable_commit}", file=sys.stderr)
             return stable_commit
         else:
             print("No promote action found or failed to get commit SHA", file=sys.stderr)

--- a/get_stable.py
+++ b/get_stable.py
@@ -3,7 +3,7 @@
 Find the latest promote action and which commit it ran for.
 """
 
-from datetime import datetime
+import sys
 
 import requests
 
@@ -52,27 +52,13 @@ def find_latest_promote_action(repo: str, owner: str = "canonical") -> str | Non
                 promote_runs.append(run)
         
         if not promote_runs:
-            print("❌ No promote workflow runs found")
-            return
+            print("❌ No promote workflow runs found", file=sys.stderr)
+            return None
         
         # Get the latest promote run
         latest_run = promote_runs[0]  # Already sorted by created_at desc
-        
-        print("🚀 Latest Promote Action Found:")
-        print("="*50)
-        print(f"Workflow Name: {latest_run['name']}")
-        print(f"Status: {latest_run['status']}")
-        print(f"Conclusion: {latest_run.get('conclusion', 'N/A')}")
-        print(f"Branch: {latest_run['head_branch']}")
-        print(f"Commit SHA: {latest_run['head_sha']}")
-        print(f"Commit Message: {latest_run.get('display_title', 'N/A')}")
-        
-        created_at = datetime.fromisoformat(latest_run["created_at"].replace("Z", "+00:00"))
-        print(f"Created: {created_at.strftime('%Y-%m-%d %H:%M:%S UTC')}")
-        print(f"Run URL: {latest_run['html_url']}")
-        
         return latest_run.get('head_sha')
 
     except requests.exceptions.RequestException as e:
-        print(f"❌ Error fetching data: {e}")
+        print(f"❌ Error fetching data: {e}", file=sys.stderr)
         return None

--- a/get_stable.py
+++ b/get_stable.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""
+Find the latest promote action and which commit it ran for.
+"""
+
+from datetime import datetime
+
+import requests
+
+
+def find_latest_promote_action(repo: str, owner: str = "canonical") -> str | None:
+    """Find the latest promote action run.
+    
+    Args:
+        repo: The GitHub repository name.
+        owner: The GitHub repository owner (default is "canonical").
+
+    Returns:
+        The commit SHA the latest promote action ran for, or None if not found.
+
+    Raises:
+        requests.exceptions.RequestException: If there is an error fetching data from GitHub.
+    """
+    
+    # GitHub API endpoint for workflow runs
+    url = f"https://api.github.com/repos/{owner}/{repo}/actions/runs"
+    
+    headers = {
+        "Accept": "application/vnd.github.v3+json",
+        "User-Agent": "Promote-Action-Checker/1.0"
+    }
+    
+    params = {
+        "per_page": 100,  # Get more runs to find promote actions
+        "status": "completed",  # Only completed runs
+        "branch": "main",
+        "event" : "workflow_dispatch"
+    }
+    
+    try:
+        response = requests.get(url, headers=headers, params=params)
+        response.raise_for_status()
+        
+        data = response.json()
+        runs = data.get("workflow_runs", [])
+        
+        # Filter for promote-related workflows
+        promote_runs = []
+        for run in runs:
+            workflow_name = run.get("name", "").lower()
+            if "promote" in workflow_name:
+                promote_runs.append(run)
+        
+        if not promote_runs:
+            print("❌ No promote workflow runs found")
+            return
+        
+        # Get the latest promote run
+        latest_run = promote_runs[0]  # Already sorted by created_at desc
+        
+        print("🚀 Latest Promote Action Found:")
+        print("="*50)
+        print(f"Workflow Name: {latest_run['name']}")
+        print(f"Status: {latest_run['status']}")
+        print(f"Conclusion: {latest_run.get('conclusion', 'N/A')}")
+        print(f"Branch: {latest_run['head_branch']}")
+        print(f"Commit SHA: {latest_run['head_sha']}")
+        print(f"Commit Message: {latest_run.get('display_title', 'N/A')}")
+        
+        created_at = datetime.fromisoformat(latest_run["created_at"].replace("Z", "+00:00"))
+        print(f"Created: {created_at.strftime('%Y-%m-%d %H:%M:%S UTC')}")
+        print(f"Run URL: {latest_run['html_url']}")
+        
+        return latest_run.get('head_sha')
+
+    except requests.exceptions.RequestException as e:
+        print(f"❌ Error fetching data: {e}")
+        return None


### PR DESCRIPTION
Compare the */stable track's documentation to Discourse,

To find the commit corresponds to the stable track the code checks the latest run `Promote charm` action and uses the sha used to run this action.

`use-stable` is the input value to use here. 

!! It is automatically enabled, if you wish to use the main branch for comparison set `use-stable` to `false`.